### PR TITLE
Limit the job queues so we don't run the new directory queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-worker:    bundle exec rake resque:work TERM_CHILD=1 QUEUES=invoicing,metrics,signup
+worker:    bundle exec rake resque:work TERM_CHILD=1 QUEUES=invoicing,metrics,signup,directoryentry
 scheduler: bundle exec rake resque:scheduler
 web:       bundle exec resque-web -L -F -s thin -o localhost config/resque-web.rb 


### PR DESCRIPTION
directory queue should only be run inside directory app.

The services-manager side of theodi/open-orgn-services#188
