### PR TITLE
update airbrake to 3.1.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       i18n (= 0.6.1)
       multi_json (~> 1.0)
     addressable (2.3.3)
-    airbrake (3.1.8)
+    airbrake (3.1.10)
       activesupport
       builder
       json


### PR DESCRIPTION
less urgent than the member-directory one.
