### PR TITLE
Put resque-scheduler into dynamic mode

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,6 +26,7 @@ namespace :resque do
       Resque::Failure.backend = Resque::Failure::Redis
     end
     # Load schedule
+    Resque::Scheduler.dynamic = true
     Resque.schedule = YAML.load_file('config/schedule.yml')
   end
 end

--- a/config/resque-web.rb
+++ b/config/resque-web.rb
@@ -9,4 +9,4 @@ require 'resque_scheduler/server'
 
 require 'open-orgn-services'
 
-Resque.schedule = YAML.load_file(File.join('config', 'schedule.yml'))
+Resque::Scheduler.dynamic = true


### PR DESCRIPTION
Schedule is stored in redis, allowing failover.
