### PR TITLE
Revert "Remove capsulesyncmonitor"

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -58,6 +58,12 @@ eventbrite:
   args:
   description: "Interrogate all events in Eventbrite"
 
+capsulesync:
+  every: 1h
+  class: CapsuleSyncMonitor
+  args:
+  description: "Sync data back to member directory from CapsuleCRM"
+  
 import_resources:
   every: 1h
   class: ImportResources


### PR DESCRIPTION
This reverts commit 01e93878a713b85c876435a074557aeda2fd4550.

The removal didn't actually cause the job to stop anyway, so putting it back makes no difference to anything.

In future, if we do want to stop jobs, we need to change the schedule, I think, not remove the job from the list.
